### PR TITLE
Add support for fluxible@0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "immutable": "^3.3.0",
-    "fluxible": "^0.2.0"
+    "fluxible": ">=0.2.0 <0.3.x"
   },
   "peerDependencies": {
     "react": "^0.12.0"

--- a/src/createImmutableStore.js
+++ b/src/createImmutableStore.js
@@ -9,7 +9,7 @@ function requireCreateStore() {
     try {
         return require('fluxible/addons/createStore');
     } catch(err) {
-        return require('fluxible/utils/createStore')
+        return require('fluxible/utils/createStore');
     }
 }
 
@@ -42,7 +42,11 @@ function setState(newState, event, payload) {
     }
 
     this._state = Immutable.fromJS(newState);
-    event ? this.emit(event, payload) : this.emitChange(payload);
+    if (event) {
+        this.emit(event, payload);
+    } else {
+        this.emitChange(payload);
+    }
     return true;
 }
 

--- a/src/createImmutableStore.js
+++ b/src/createImmutableStore.js
@@ -5,7 +5,15 @@
  */
 'use strict';
 
-var createStore = require('fluxible/utils/createStore');
+function requireCreateStore() {
+    try {
+        return require('fluxible/addons/createStore');
+    } catch(err) {
+        return require('fluxible/utils/createStore')
+    }
+}
+
+var createStore = requireCreateStore();
 var Immutable = require('immutable');
 
 function merge(dest, src) {


### PR DESCRIPTION
[fluxible@0.3](https://github.com/yahoo/fluxible/releases/tag/v0.3.0) moved the `createStore` file with a deprecation warning when using the old path.

Options
- I don't like this try catch but it would be one way to support multiple fluxible versions
- An alternative, which may or may not be a good idea, would be to swap the `fluxible` dep for [`dispatchr`](https://github.com/yahoo/dispatchr) since [fluxible's createStore](https://github.com/yahoo/fluxible/blob/a4d86424430adfa464df5597a983b10a11857465/addons/createStore.js) just uses that under the hood anyways
- We could also support only the latest versions of `fluxible`

@akshayp @dmhood Thoughts?