### PR TITLE
should not warn for children and Immutable state object

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coveralls": "^2.11.1",
     "eslint": "^0.17.0",
     "istanbul": "^0.3.2",
-    "jsx-test": "^0.3.0",
+    "jsx-test": "^0.4.1",
     "mocha": "^2.0",
     "pre-commit": "^1.0",
     "sinon": "^1.14.1"

--- a/src/createImmutableStore.js
+++ b/src/createImmutableStore.js
@@ -7,14 +7,7 @@
 
 var createStore = require('fluxible/utils/createStore');
 var Immutable = require('immutable');
-
-function merge(dest, src) {
-    Object.keys(src).forEach(function cb(prop) {
-        dest[prop] = src[prop];
-    });
-
-    return dest;
-}
+var utils = require('./utils');
 
 function initialize() {
     this._state = Immutable.Map();
@@ -59,7 +52,7 @@ function mergeState(stateFragment, event, payload) {
  * @return {Store} Store class
  **/
 module.exports = function createImmutableStore(spec) {
-    return createStore(merge({
+    return createStore(utils.merge({
         initialize: initialize,
         rehydrate: rehydrate,
         dehydrate: dehydrate,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+    merge: function merge(dest, src) {
+        dest || (dest = {});
+
+        src && typeof src === 'object' && Object.keys(src).forEach(function mergeCb(prop) {
+            dest[prop] = src[prop];
+        });
+
+        return dest;
+    }
+};

--- a/tests/unit/ComponentMixin.js
+++ b/tests/unit/ComponentMixin.js
@@ -37,7 +37,7 @@ describe('ImmutableMixin component functions', function () {
             expect(console.warn.callCount).to.equal(0);
         });
 
-        it('should bypass certain state fields if are ignored', function (done) {
+        it('should warn certain if next state is mutable', function (done) {
             var Component = React.createClass({
                 displayName: 'MyComponent',
                 mixins: [ImmutableMixin],
@@ -48,7 +48,30 @@ describe('ImmutableMixin component functions', function () {
 
             var comp = jsx.renderComponent(Component, {});
             comp.setState({testData: {list: [1, 2, 3]}}, function () {
-                console.warn.calledWith('WARN: component: MyComponent received non-immutable object: testData');
+                expect(
+                    console.warn.calledWith('WARN: component: MyComponent received non-immutable object: testData')
+                ).to.equal(true);
+                done();
+            });
+        });
+
+        it('should bypass certain state fields if are ignored', function (done) {
+            var Component = React.createClass({
+                displayName: 'MyComponent',
+                mixins: [ImmutableMixin],
+                objectsToIgnore: {
+                    state: {
+                        testData: true
+                    }
+                },
+                render: function () {
+                    return null;
+                }
+            });
+
+            var comp = jsx.renderComponent(Component, {});
+            comp.setState({testData: {list: [1, 2, 3]}}, function () {
+                expect(console.warn.callCount).to.equal(0);
                 done();
             });
         });

--- a/tests/unit/ComponentMixin.js
+++ b/tests/unit/ComponentMixin.js
@@ -75,6 +75,27 @@ describe('ImmutableMixin component functions', function () {
                 done();
             });
         });
+
+        it('should merge w/ default certain state fields if are ignored', function (done) {
+            var Component = React.createClass({
+                displayName: 'MyComponent',
+                mixins: [ImmutableMixin],
+                objectsToIgnore: {
+                    state: {
+                        testData: true
+                    }
+                },
+                render: function () {
+                    return React.createElement('div', {}, this.props.children);
+                }
+            });
+
+            var comp = jsx.renderComponent(Component, {}, ['foo', 'bar']);
+            comp.setState({testData: {list: [1, 2, 3]}}, function () {
+                expect(console.warn.callCount).to.equal(0);
+                done();
+            });
+        });
     });
 
     describe('#componentWillMount', function () {


### PR DESCRIPTION
This [test](https://github.com/yahoo/fluxible-immutable-utils/pull/8/files#diff-d578bce4a4be6bf75a06033d7f7db28bR104) will be uneffective until yahoo/jsx-test#5 is merged