### PR TITLE
Update repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yahoo/fluxible-immutable-utils"
+    "url": "https://github.com/yahoo/fluxible-immutable-utils.git"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:yahoo/fluxible-immutable-utils.git#master"
+    "url": "https://github.com/yahoo/fluxible-immutable-utils"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
The link on the side to open the repo in npm is busted:
https://www.npmjs.com/package/fluxible-immutable-utils

Link:
https://www.dropbox.com/s/6b0ia3cd9fwcldg/Screenshot%202015-04-16%2015.57.41.png?dl=0

Result:
https://www.dropbox.com/s/97jp728y0wzf1il/Screenshot%202015-04-16%2015.58.11.png?dl=0