### PR TITLE
support react@0.13 and later fluxible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fluxible-immutable-utils",
   "author": "dhood@yahoo-inc.com",
   "description": "A collection of utilities that provide convenience methods for using Immutable.js with a fluxible based application",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -16,17 +16,15 @@
   },
   "dependencies": {
     "immutable": "^3.3.0",
-    "fluxible": "^0.2.0"
-  },
-  "peerDependencies": {
-    "react": "^0.12.0"
+    "fluxible": "^0.4.0",
+    "react": "^0.13.0"
   },
   "devDependencies": {
     "chai": "^2.0.0",
     "coveralls": "^2.11.1",
     "eslint": "^0.17.0",
     "istanbul": "^0.3.2",
-    "jsx-test": "^0.4.1",
+    "jsx-test": "^0.4.2",
     "mocha": "^2.0",
     "pre-commit": "^1.0",
     "sinon": "^1.14.1"

--- a/src/createImmutableStore.js
+++ b/src/createImmutableStore.js
@@ -5,9 +5,9 @@
  */
 'use strict';
 
-var createStore = require('fluxible/utils/createStore');
 var Immutable = require('immutable');
 var utils = require('./utils');
+var createStore = require('fluxible/addons/createStore');
 
 function initialize() {
     this._state = Immutable.Map();


### PR DESCRIPTION
- Since we explicitly requires `react`, not a global plugin system like `grunt` or `express` & `npm` keeps throwing warnings for `peerDependencies`, move to `dependencies` instead.
- Support later `fluxible` versions & `react` also
- fix #12 