### PR TITLE
Revert back to React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "test": "npm run lint && npm run cover"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "dependencies": {
     "immutable": "^3.3.0",
     "fluxible": "^1.0.0",
     "fluxible-addons-react": "^0.2.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
+    "react-addons-shallow-compare": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",
@@ -37,8 +37,8 @@
     "mocha": "^2.0",
     "pre-commit": "^1.0",
     "object-assign": "^4.0.1",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "sinon": "^1.14.1"
   },
   "pre-commit": [


### PR DESCRIPTION
@mridgway 

This accidentally broke builds as they started pulling in React 15. We will need to bump the major version to avoid breaking builds later.