### PR TITLE
React 15 upgrade

### DIFF
--- a/lib/createImmutableContainer.js
+++ b/lib/createImmutableContainer.js
@@ -8,8 +8,8 @@
 
 var React = require('react');
 var connectToStores = require('fluxible-addons-react/connectToStores');
+var shallowequal = require('shallowequal');
 var utils = require('../internals/utils');
-var shallowCompare = require('react-addons-shallow-compare');
 
 function getIgnoredProps(ignore) {
     if (!Array.isArray(ignore)) {
@@ -67,7 +67,7 @@ module.exports = function createImmutableContainer(Component, options) {
         shouldComponentUpdate: function (nextProps, nextState) {
             // Backward compatibility for components with no state
             nextState = nextState || null;
-            return shallowCompare(this, nextProps, nextState);
+            return !shallowequal(this.props, nextProps) || !shallowequal(this.state, nextState);
         },
 
         render: function () {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "test": "npm run lint && npm run cover"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "immutable": "^3.3.0",
     "fluxible": "^1.0.0",
     "fluxible-addons-react": "^0.2.0",
-    "react-addons-shallow-compare": "^0.14.0"
+    "immutable": "^3.3.0",
+    "shallowequal": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",
@@ -33,12 +33,12 @@
     "grunt-babel": "^5.0.1",
     "grunt-contrib-clean": "^0.6.0",
     "istanbul": "^0.4.0",
-    "jsx-test": "^0.8.0",
+    "jsx-test": "^1.0.0",
     "mocha": "^2.0",
     "pre-commit": "^1.0",
     "object-assign": "^4.0.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "sinon": "^1.14.1"
   },
   "pre-commit": [


### PR DESCRIPTION
@redonkulus make package compatible with React 15, swap out `react-addons-shallow-compare` so that we dont need to bump major version, also can fix https://github.com/yahoo/fluxible-immutable-utils/issues/43

c.c.@gingur 