### PR TITLE
Use latest version of shallowequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fluxible": "^1.0.0",
     "fluxible-addons-react": "^0.2.0",
     "immutable": "^3.3.0",
-    "shallowequal": "^0.2.0"
+    "shallowequal": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",


### PR DESCRIPTION
@redonkulus [shallowequal](https://github.com/dashed/shallowequal) maintains the same API as the previous major verison [changes](https://github.com/dashed/shallowequal/compare/d63d2faf85260852fb32c47db1c7c01d630d5569...HEAD) but has a number of improvements, notably the omission of a dependency on `lodash.keys` which in turn depends on `lodash._getnative`, `lodash.isarguments`, `lodash.isarray`.

Since this is something that will end up client-side, it's nice to remove modules that we don't really need.

- [1.0.1 = 1198 bytes](https://wzrd.in/standalone/shallowequal@1.0.1)
- [0.2.2 = 4408 bytes](https://wzrd.in/standalone/shallowequal@0.2.2)
